### PR TITLE
Fail if new data not yet available

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.tweetReport = async (req, res) => {
     date = dayjs().tz("America/Toronto");
   }
 
-  const results = await getResults(date);
+  const results = await getResults(date).catch(err => res.status(400).send(err));
 
   let message = 
     `${results.torontoNewCases} new cases of COVID-19 in Toronto yesterday` +
@@ -47,7 +47,7 @@ function getResults(date) {
         return axios.get(reportURL);
     })
   ).then(results => {
-    if (results[0].status === "rejected") Promise.reject("Today's data not available yet.");
+    if (results[0].status === "rejected") reject("Today's data not available yet.");
     const responses = results
                         .filter(result => result.status === "fulfilled")
                         .map(result => result.value);

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function getResults(date) {
         return axios.get(reportURL);
     })
   ).then(results => {
+    if (results[0].status === "rejected") Promise.reject("Today's data not available yet.");
     const responses = results
                         .filter(result => result.status === "fulfilled")
                         .map(result => result.value);

--- a/tests/tweet.test.js
+++ b/tests/tweet.test.js
@@ -1,10 +1,23 @@
 const { postTweet, tweetReport } = require("..");
 const { getMockReq, getMockRes } = require('@jest-mock/express');
 const { v4: uuidv4 } = require('uuid');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 test("post tweet", async () => {
     const uuid = uuidv4();
     expect(postTweet(uuid)).resolves;
+})
+
+test("fail if new data not yet available", async () => {
+  const dateString = dayjs().tz("America/Toronto").add(1, 'day').format("YYYY-MM-DD");
+  const req = getMockReq({ query: {date: dateString} });
+  const { res } = getMockRes();
+  await tweetReport(req, res);
+  expect(res.status).toHaveBeenCalledWith(400);
 })
 
 test("end-to-end with date param", async () => {


### PR DESCRIPTION
Fix bug where tweet posts immediately even though new data not yet available. Program responds with 400 if it fails to retrieve today's data.