### PR TITLE
return Promise.reject() when new data not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.swp
 tests/jest.env.js
+.devenv

--- a/index.js
+++ b/index.js
@@ -15,17 +15,21 @@ exports.tweetReport = async (req, res) => {
     date = dayjs().tz("America/Toronto");
   }
 
-  const results = await getResults(date).catch(err => res.status(400).send(err));
 
-  let message = 
-    `${results.torontoNewCases} new cases of COVID-19 in Toronto yesterday` +
-    ` and ${results.ontarioNewCases} in Ontario.` +
-    ` 7-day averages are ${results.toronto7DayAvg} and ${results.ontario7DayAvg} respectively.` +
-    ` #toronto #covid19 #coronavirus`;
+  return getResults(date)
+    .then(results => {
 
-  return postTweet(message)
-           .then(result => res.status(200).send())
-           .catch(err => res.status(400).send(err));
+      let message = 
+        `${results.torontoNewCases} new cases of COVID-19 in Toronto yesterday` +
+        ` and ${results.ontarioNewCases} in Ontario.` +
+        ` 7-day averages are ${results.toronto7DayAvg} and ${results.ontario7DayAvg} respectively.` +
+        ` #toronto #covid19 #coronavirus`;
+
+      return postTweet(message);
+    })
+    .then(result => res.status(200).send())
+    .catch(err => res.status(400).send(err));
+
 }
 
 function postTweet(message) {
@@ -47,7 +51,7 @@ function getResults(date) {
         return axios.get(reportURL);
     })
   ).then(results => {
-    if (results[0].status === "rejected") reject("Today's data not available yet.");
+    if (results[0].status === "rejected") return Promise.reject("Today's data not available yet.");
     const responses = results
                         .filter(result => result.status === "fulfilled")
                         .map(result => result.value);

--- a/tests/tweet.test.js
+++ b/tests/tweet.test.js
@@ -18,6 +18,7 @@ test("fail if new data not yet available", async () => {
   const { res } = getMockRes();
   await tweetReport(req, res);
   expect(res.status).toHaveBeenCalledWith(400);
+  expect(res.send).toHaveBeenCalledWith("Today's data not available yet.");
 })
 
 test("end-to-end with date param", async () => {


### PR DESCRIPTION
Without the return and restructure, the tweet is posted anyways even if the new data is not found.